### PR TITLE
Added Dark Mode Support for Disabled Tiles [Fixes Issue #40]

### DIFF
--- a/src/components/MenuBox.jsx
+++ b/src/components/MenuBox.jsx
@@ -37,6 +37,7 @@
 */
 
 import {
+  useColorMode,
   Box,
   Flex,
   GridItem,
@@ -101,6 +102,9 @@ export default function MenuBox({ category }) {
     }
   };
 
+  const colorMode = useColorMode();
+  const bgColor = condition ? "#2e2e2e" : "transparent";
+
   return (
     <GridItem
       as={motion.div}
@@ -116,7 +120,7 @@ export default function MenuBox({ category }) {
       alignItems="center"
       justifyContent="space-between"
       borderColor={useColorModeValue("#0050e0", "#f3f3f3")}
-      backgroundColor={useColorModeValue("#0050e0", "transparent")}
+      backgroundColor={useColorModeValue("#0050e0",bgColor)}
       className={`menu-box span-${span} ${condition ? "disabled" : ""}`}
       rounded="0.75rem"
       p={{ sm: 2, md: 4, lg: 6 }}>

--- a/src/components/MenuBox.jsx
+++ b/src/components/MenuBox.jsx
@@ -37,7 +37,6 @@
 */
 
 import {
-  useColorMode,
   Box,
   Flex,
   GridItem,
@@ -102,7 +101,6 @@ export default function MenuBox({ category }) {
     }
   };
 
-  const colorMode = useColorMode();
   const bgColor = condition ? "#2e2e2e" : "transparent";
 
   return (

--- a/src/components/settings/LanguagePicker.jsx
+++ b/src/components/settings/LanguagePicker.jsx
@@ -66,7 +66,7 @@ function LanguagePicker() {
     // It is needed to fetch the translated assets
     document.location.reload();
   }
-  return (<Flex mb={"0.5rem"} justifyContent={"center"} alignItems={"center"} columnGap={"2rem"}>
+  return (<Flex mb={"1.5rem"} justifyContent={"center"} alignItems={"center"} columnGap={"2rem"}>
     {i18n.t("change_language")}
     <GreekFlag onClick={() => changeLanguage("el")} />
     <UKFlag onClick={() => changeLanguage("en")} />

--- a/src/components/settings/LanguagePicker.jsx
+++ b/src/components/settings/LanguagePicker.jsx
@@ -66,7 +66,7 @@ function LanguagePicker() {
     // It is needed to fetch the translated assets
     document.location.reload();
   }
-  return (<Flex mb={"1.5rem"} justifyContent={"center"} alignItems={"center"} columnGap={"2rem"}>
+  return (<Flex mb={"0.5rem"} justifyContent={"center"} alignItems={"center"} columnGap={"2rem"}>
     {i18n.t("change_language")}
     <GreekFlag onClick={() => changeLanguage("el")} />
     <UKFlag onClick={() => changeLanguage("en")} />


### PR DESCRIPTION
Fixes: #40 

Inactive / Disabled Tiles could not be differentiated in Dark Mode. This UI issue is fixed now.

Old Picture :-

![ui](https://github.com/open-source-uom/myuom/assets/117531461/88c8fdb7-df11-47e6-ae18-c4292f156e9b)

New Picture (After Pull Request) :-

![dark](https://github.com/open-source-uom/myuom/assets/117531461/6c44d685-2b4e-4f33-aad5-33afbd320019)
