### PR TITLE
Broken Image Links replaced by default Image Link [ Fixes #52 ]

### DIFF
--- a/src/assets/data/professors/Economics.js
+++ b/src/assets/data/professors/Economics.js
@@ -177,7 +177,8 @@ export const professors =
                 office: '308'
             },
             {
-                imgUrl: 'https://www.uom.gr/assets/site/public/nodes/8623/8100-PHOTO-2.png',
+                // imgUrl: 'https://www.uom.gr/assets/site/public/nodes/8623/8100-PHOTO-2.png',
+                imgUrl: 'https://www.uom.gr/site/images/personphoto-2.jpg',
                 fname: 'katerina',
                 lname: 'litina',
                 title: 'epikouriKathigitria',

--- a/src/assets/data/professors/EuropeanStudies.js
+++ b/src/assets/data/professors/EuropeanStudies.js
@@ -115,7 +115,8 @@ export const professors =
                 office: '421B'
             },
             {
-                imgUrl: 'https://www.uom.gr/assets/site/public/nodes/1731/1190-icons-2.jpg',
+                // imgUrl: 'https://www.uom.gr/assets/site/public/nodes/1731/1190-icons-2.jpg',
+                imgUrl: 'https://www.uom.gr/site/images/personphoto-2.jpg',
                 fname: i18n.t('ioannis'),
                 lname: i18n.t('konstantinidis'),
                 title: i18n.t('anaplirotisKathigitis'),

--- a/src/assets/data/professors/Informatics.js
+++ b/src/assets/data/professors/Informatics.js
@@ -305,7 +305,8 @@ export const professors =
                 office: '520'
             },
             {
-                imgUrl: 'https://www.uom.gr/assets/site/public/nodes/1540/1217-spetrido-2.jpg',
+                // imgUrl: 'https://www.uom.gr/assets/site/public/nodes/1540/1217-spetrido-2.jpg',
+                imgUrl: 'https://www.uom.gr/site/images/personphoto-2.jpg',
                 fname: i18n.t('sofia'),
                 lname: i18n.t('petridou'),
                 title: i18n.t('epikouriKathigitria'),


### PR DESCRIPTION
This PR fixes #52 

The Broken Image Links present in three instances of the Academic Personnel Section is replaced by the default Image Link for cards without any Images.

Changes done :- 

![Screenshot 2024-03-06 235708](https://github.com/open-source-uom/myuom/assets/117531461/f809b4b9-6fc4-4fb7-8c86-1dbe7a5c8dd8)

![Screenshot 2024-03-06 235741](https://github.com/open-source-uom/myuom/assets/117531461/90b6c048-6808-4392-a683-1c82442af421)

![Screenshot 2024-03-06 235800](https://github.com/open-source-uom/myuom/assets/117531461/ed656c10-514f-4bf7-84ae-1aa78c643c88)

