### PR TITLE
Fixed graduation links and language of error messages

### DIFF
--- a/src/components/MenuBox.jsx
+++ b/src/components/MenuBox.jsx
@@ -48,6 +48,7 @@ import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import { DiagonalRightArrowIcon, RightArrowIcon } from "../assets/icons";
 import { useDepName, useDepartments } from "../hooks";
+import i18n from "../i18n";
 
 export default function MenuBox({ category }) {
   const { title, iconSVG, route, span, isExternal, requireSelection } =
@@ -88,8 +89,8 @@ export default function MenuBox({ category }) {
       if (!toast.isActive(id)) {
         toast({
           id,
-          title: "Δεν έχει επιλεγεί τμήμα",
-          description: "Παρακαλώ επιλέξτε τμήμα από τις ρυθμίσεις",
+          title: i18n.t("error_title"),
+          description: i18n.t("error_description"),
           status: "error",
           duration: 5000,
           isClosable: true,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -54,6 +54,10 @@ const resources = {
       faq_title: "Frequently Asked",
       faq_subtitle: "You will find answers that might be of interest to you.",
       masters: "Masters",
+      error_title: "No Department selected",
+      error_description: "Please select Department from Settings",
+      graduation_redirection_message:"Redirecting to section",
+      graduation_description:"Graduation information will be available on selection from settings soon."
       // //constants.js --> offices
       // // offices: "Offices",
       // // liaison_office: "Liason Office",
@@ -106,7 +110,11 @@ const resources = {
       freshmen_guides: "Πρωτοετείς",
       faq_title: "Συχνές Ερωτήσεις",
       faq_subtitle: "Εδώ θα βρείτε απαντήσεις σε ερωτήσεις που ενδέχεται να σας ενδιαφέρουν.",
-      masters: "Μεταπτυχιακά"
+      masters: "Μεταπτυχιακά",
+      error_title: "Δεν έχει επιλεγεί τμήμα",
+      error_description: "Παρακαλώ επιλέξτε τμήμα από τις ρυθμίσεις",
+      graduation_redirection_message:"Ανακατεύθυνση στο τμήμα",
+      graduation_description:"Παρακαλώ επιλέξτε τμήμα από τις ρυθμίσεις."
       //constants.js
       // offices: "Γραφεία",
       // liaison_office: "Γραφείο Διασύνδεσης",

--- a/src/pages/AnnouncementPage.jsx
+++ b/src/pages/AnnouncementPage.jsx
@@ -40,6 +40,7 @@ import { useEffect } from "react";
 import { Heading, Box, useToast } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { useDepName, useAnnouncementLink } from "../hooks";
+import i18n from "../i18n";
 
 export default function AnnouncementsPage() {
   const [, depCode] = useDepName();
@@ -50,8 +51,8 @@ export default function AnnouncementsPage() {
   useEffect(() => {
     if (!depCode) {
       toast({
-        title: "Δεν έχει επιλεγεί τμήμα",
-        description: "Παρακαλώ επιλέξτε τμήμα από τις ρυθμίσεις",
+        title: i18n.t("error_title"),
+        description: i18n.t("error_description"),
         status: "error",
         duration: 5000,
         isClosable: true,

--- a/src/pages/GraduationPage.jsx
+++ b/src/pages/GraduationPage.jsx
@@ -36,10 +36,11 @@
 
 */
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Heading, Box, useToast } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { useDepName, useGraduationLink } from '../hooks';
+import i18n from "../i18n";
 
 export default function GraduationPage() {
 
@@ -47,11 +48,13 @@ export default function GraduationPage() {
   const toast = useToast();
   const navigate = useNavigate();
   const gradLink = useGraduationLink(depCode);
+  const hasOpenedLinkRef = useRef(false);
+
   useEffect(() => {
     if (!depCode) {
       toast({
-        title: "Δεν έχει επιλεγεί τμήμα",
-        description: "Παρακαλώ επιλέξτε τμήμα από τις ρυθμίσεις",
+        title: i18n.t("error_title"),
+        description: i18n.t("error_description"),
         status: "error",
         duration: 5000,
         isClosable: true,
@@ -60,23 +63,24 @@ export default function GraduationPage() {
     }
     if (gradLink) {
       window.open(gradLink.link);
-      navigate("/")
+      navigate("/");
+      hasOpenedLinkRef.current = true;
     }
 
-  }, [depCode]);
+  }, [depCode, gradLink, navigate, toast]);
 
   return (
     <Box>
       {gradLink ? (
         <Heading textAlign="center" marginTop="50px">
-          Ανακατεύθυνση στο τμήμα
-          <a href={gradLink} target="_blank" rel="noreferrer">
-            {gradLink}
+          {i18n.t("graduation_redirection_message")}
+          <a href={gradLink.link} target="_blank" rel="noreferrer">
+            {gradLink.link}
           </a>
         </Heading>
       ) : (
         <Heading textAlign="center" marginTop="50px">
-          Παρακαλώ επιλέξτε τμήμα από τις ρυθμίσεις.
+          {i18n.t("graduation_description")}
         </Heading>
       )}
     </Box>


### PR DESCRIPTION
The a tag was missing .link attribute and added new English translations in i18n file for easy read-ability for non-native users.


https://github.com/open-source-uom/myuom/assets/100429756/5420c2af-d27c-49bb-8920-6d4ae43a1fa2

