### PR TITLE
Fix for persistent personnel cards on department switching

### DIFF
--- a/src/components/professors/ProfList.jsx
+++ b/src/components/professors/ProfList.jsx
@@ -110,8 +110,8 @@ export default function ProfList() {
       </InputGroup>
 
       {filteredArray.length ? (
-        filteredArray.map((prof) => (
-          <ProfComponent prof={prof} key={prof.tel} />
+        filteredArray.map((prof,index) => (
+          <ProfComponent prof={prof} key={index} />
         ))
       ) : (
         <Text as="h1" fontFamily="Syne">

--- a/src/components/professors/ProfList.jsx
+++ b/src/components/professors/ProfList.jsx
@@ -110,8 +110,8 @@ export default function ProfList() {
       </InputGroup>
 
       {filteredArray.length ? (
-        filteredArray.map((prof,index) => (
-          <ProfComponent prof={prof} key={index} />
+        filteredArray.map((prof) => (
+          <ProfComponent prof={prof} key={`${prof.email}-${prof.tel}`} />
         ))
       ) : (
         <Text as="h1" fontFamily="Syne">


### PR DESCRIPTION
This PR fixes issue #54 

The changes are made in the map method in ProfList.js and it now uses array index as a key.