### PR TITLE
Fixed Bug in Announcement Section for Accounting and Finance Department

### DIFF
--- a/src/assets/data/announcements.js
+++ b/src/assets/data/announcements.js
@@ -63,7 +63,7 @@ export const AnnouncementsData = [
     code: DEPARTMENT_CODES.ECONOMICS,
     link: "https://www.uom.gr/eco#undefined1",
   }, {
-    code: DEPARTMENT_CODES.FINANCE,
+    code: DEPARTMENT_CODES.ACCOUNTING_FINANCE,
     link: "https://www.uom.gr/fin",
   }, {
     code: DEPARTMENT_CODES.MUSIC,


### PR DESCRIPTION
fixes #58 

This Bug was caused due to a typo in writing the department code for the Accounting and Finance Department, which resulted in showing erroneous message.

Pic After Fixing Bug :- 

![Screenshot 2024-03-08 010206](https://github.com/open-source-uom/myuom/assets/117531461/48a68c43-74bf-4f04-a6bd-3451ad6a4105)
