### PR TITLE
Capitalize and translate Professors' names

### DIFF
--- a/src/components/professors/ProfCard.jsx
+++ b/src/components/professors/ProfCard.jsx
@@ -106,8 +106,9 @@ export default function ProfCard({ prof }) {
               justifyContent="start"
               fontWeight="bold"
               fontSize={{ sm: 14, md: 16, lg: 18 }}
+              textTransform={"capitalize"}
             >
-              {prof.fname} {prof.lname}
+              {t(prof.fname)} {t(prof.lname)}
             </Text>
             <AccordionIcon />
           </AccordionButton>


### PR DESCRIPTION
fixes #70 

Changes done:
1. Add t() function from i18n to prof.fname and prof.lname
2. Add text-transform CSS property to professor's name