### PR TITLE
Reference github instead gitlab social icon

### DIFF
--- a/src/assets/data/SocialMediaUrls.js
+++ b/src/assets/data/SocialMediaUrls.js
@@ -5,6 +5,6 @@ export const SOCIAL_MEDIA_URLS = {
         "https://www.youtube.com/channel/UC98Ggzq6dl_nn5Y0BHb6SLA?sub_confirmation=1",
     twitter: "https://twitter.com/opensource_uom",
     LinkedIn: "https://www.linkedin.com/company/80766091/",
-    gitlab: "https://gitlab.com/opensourceuom",
+    github: "https://github.com/open-source-uom/myuom",
     discord: "https://discord.com/invite/XtxtM3ZHUm",
 };

--- a/src/assets/locales/el/settings_page.js
+++ b/src/assets/locales/el/settings_page.js
@@ -6,7 +6,7 @@ export default {
     license: "Άδεια Χρήσης",
     app_manual: "Εγχειρίδιο Εφαρμογής",
     share_app: "Κοινοποιήστε την εφαρμογή",
-    gitlab_contribute: "Συνεισφέρετε στο έργο μας",
+    github_contribute: "Συνεισφέρετε στο έργο μας",
     settings_close: "Κλείσιμο",
     change_language: "Αλλαγή Γλώσσας",
     choose_department: "Επιλέξτε Τμήμα",

--- a/src/assets/locales/en/settings_page.js
+++ b/src/assets/locales/en/settings_page.js
@@ -6,7 +6,7 @@ export default {
     license: "License",
     app_manual: "App Manual",
     share_app: "Share this App",
-    gitlab_contribute: "Contribute to our Projects",
+    github_contribute: "Contribute to our Projects",
     settings_close: "Close",
     change_language: "Change Language",
     choose_department: "Choose Department",

--- a/src/components/settings/SettingsDrawer.jsx
+++ b/src/components/settings/SettingsDrawer.jsx
@@ -16,7 +16,6 @@ import {
     FaInfoCircle,
     FaFileAlt,
     FaShareAlt,
-    FaGitlab,
     FaGithub,
     FaBook,
     FaRegComment,

--- a/src/components/settings/SettingsDrawer.jsx
+++ b/src/components/settings/SettingsDrawer.jsx
@@ -17,6 +17,7 @@ import {
     FaFileAlt,
     FaShareAlt,
     FaGitlab,
+    FaGithub,
     FaBook,
     FaRegComment,
 } from "react-icons/fa";
@@ -125,7 +126,7 @@ export function SettingsDrawer({ isOpen, onClose }) {
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >
-                                <SettingsOption Icon={FaGitlab} onClick={onClose} text={i18n.t("gitlab_contribute")} />
+                                <SettingsOption Icon={FaGithub} onClick={onClose} text={i18n.t("github_contribute")} />
                             </a>
                             <a
                                 href="https://docs.google.com/forms/u/2/d/e/1FAIpQLSduM517c4OtIs-CNv5cjQtYcj6OXRDtCP6x0Q7d4Ymhd3xQMg/viewform"

--- a/src/components/settings/SettingsDrawer.jsx
+++ b/src/components/settings/SettingsDrawer.jsx
@@ -105,7 +105,7 @@ export function SettingsDrawer({ isOpen, onClose }) {
                             </Link>
 
                             <a
-                                href="https://gitlab.com/opensourceuom/myUoM/-/blob/main/LICENSE"
+                                href="https://github.com/open-source-uom/myuom/blob/main/LICENSE"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >
@@ -121,7 +121,7 @@ export function SettingsDrawer({ isOpen, onClose }) {
                             </a>
                             <SettingsOption Icon={FaShareAlt} onClick={handleShare} text={i18n.t("share_app")} />
                             <a
-                                href="https://gitlab.com/opensourceuom/myUoM"
+                                href="https://github.com/open-source-uom/myuom"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >

--- a/src/pages/AboutSettingsPage.jsx
+++ b/src/pages/AboutSettingsPage.jsx
@@ -90,7 +90,7 @@ function AboutSettingsPage() {
           style={{ marginRight: "0.5rem" }}
         />
         <SocialIcon
-          url={SOCIAL_MEDIA_URLS.gitlab}
+          url={SOCIAL_MEDIA_URLS.github}
           style={{ marginRight: "0.5rem" }}
         />
         <SocialIcon


### PR DESCRIPTION
Reference github instead gitlab social icon and LICENSE

### Before change
![image](https://github.com/open-source-uom/myuom/assets/91419219/25b9b026-a71c-434f-9265-97696269a3d7)


### After change
![image](https://github.com/open-source-uom/myuom/assets/91419219/335ca4ba-fd0b-4011-bc71-87200966bf51)
