### PR TITLE
fix: make header logo accessible via keyboard

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -91,12 +91,14 @@ export default function Header() {
             justifyContent="space-between"
             w={{ sm: "100%", lg: "fit-content" }}
           >
-            <Image
-              src={myUOMLogo}
+            <Box
+              as="button"
               onClick={goToHomePage}
               cursor="pointer"
-              w={{ sm: "40px", xl: "60px" }}
-            />
+              aria-label={i18n.t("home_page") || "Home Page"}
+            >
+              <Image src={myUOMLogo} w={{ sm: "40px", xl: "60px" }} />
+            </Box>
             <Box
               display={{ sm: "block", lg: "none" }}
               className={useColorModeValue("light-mode-svg", "dark-mode-svg")}


### PR DESCRIPTION
fixes #360 

Wrapped the logo `Image` component in a Chakra UI `Box` with `as="button"`. This ensures the logo is focusable and actionable using the keyboard.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
## Motivation and Context
To ensure the application is accessible to all users, including those relying on keyboard navigation.
## How Has This Been Tested?
- **Manual Verification:** Verified that the logo can be focused using the Tab key and activated using the Enter/Space keys to navigate to the home page.
- **Build:** Verified that `npm run build` completes successfully.
## Screenshots or GIF (In case of UI changes):
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.